### PR TITLE
MAINT: adjust scripts for github PAT auth

### DIFF
--- a/confluence_template.sh
+++ b/confluence_template.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
-
+# Use this file to authenticate confluence-writing cron jobs.
+# You can get a confluence PAT in the confluence settings.
+# For the user who is to run the cron jobs:
+# 1. Copy this to your home area as ~/.confluence.sh
+# 2. Change the write permissions so that nobody but you can rwx it:
+#    chmod 700 ~/.confluence.sh
+# 3. Replace the information as appropriate.
 export CONFLUENCE_USER="your-username-here"
 export CONFLUENCE_TOKEN="write-token-goes-here"

--- a/create-new-slac-epics-repos.sh
+++ b/create-new-slac-epics-repos.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Usage: ./create-new-slac-epics-repos.sh
+#  Creates new GitHub-mirrored EPICS module packages with a remote
+#  named "github-slac".
+#
+#  Requires an SSH key that is:
+#    1. Configured with GitHub
+#    2. Added to your SSH agent (see ssh-add -l)
+#
+#  Additionally requires the "gh" command-line tool (as available in pcds-envs)
+#  in your PATH.
+
+if ! command -v gh >/dev/null; then
+  echo "gh command-line tool unavailable on PATH." >/dev/stderr
+  exit 1
+fi
+
+repo_list_output=$(gh repo list slac-epics -L 10000 --json name --jq ".[].name")
+
+if [ -z "$repo_list_output" ]; then
+    echo "Unable to enumerate existing repositories. Is gh configured correctly?"
+    exit 1
+fi
+
+readarray -t existing_repos <<< "$repo_list_output"
+declare -p existing_repos 2>/dev/null
+# -> existing_repos is a bash array of all slac-epics modules
+
+does_repo_exist() {
+    local repo_to_check
+    local repo
+    repo_to_check=${1,,}
+
+    for repo in "${existing_repos[@]}"; do
+        if [[ "${repo,,}" = "$repo_to_check" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+
+for gitdir in ${GIT_TOP}/package/epics/modules/*.git
+do
+    # Skip symlinks
+    if [ -L "$gitdir" ]; then
+        echo "Skipping symlink $gitdir ..."
+        continue
+    fi
+
+    pushd "$gitdir" &> /dev/null || continue
+
+    gitname=$(basename $gitdir)
+    repo_name=${gitname/.git/}
+    full_repo_name="slac-epics/$repo_name"
+
+    if does_repo_exist $repo_name; then
+        echo "* $(basename $gitdir) is already on slac-epics"
+    else
+        echo "* Creating new repository $full_repo_name for $gitdir ..."
+        git config --global --add safe.directory $gitdir &> /dev/null
+        (cd /tmp && \
+            gh repo create --confirm --enable-issues --enable-wiki --public \
+            -d "${repo_name}: Mirror for $gitdir" $full_repo_name \
+        ) || echo "gh repo create failed; maybe repository already exists?"
+        git remote add github-slac git@github.com:$full_repo_name
+        git remote add github-slac-https https://github.com/$full_repo_name
+        # git push --mirror github-slac
+    fi
+    popd &> /dev/null || exit 1
+done

--- a/pcdshub_template.sh
+++ b/pcdshub_template.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Use this file to authenticate pcdshub-pushing cron jobs.
+# You can get a github fine-grained PAT in the github settings.
+#
+# You need the following permissions:
+# 1. Read access to metadata
+# 2. Write access to contents
+# 3. Write access to pull requests
+#
+# For the following repositories:
+# pcdshub/
+#     device_config
+#     gateway-setup
+#     epics-setup
+#     epics-config
+#     all-deployed-iocs
+#     iocCommon-rhel7
+#     iocCommon-All
+#     iocCommon-hosts
+#     IocManager
+#     pvNotepad
+#     eco_tools
+#     current-hutch-python-backup
+#     plc-summary
+#
+# For the user who is to run the cron jobs:
+# 1. Copy this to your home area as ~/.pcdshub.sh
+# 2. Change the write permissions so that nobody but you can rwx it:
+#    chmod 700 ~/.pcdshub.sh
+# 3. Replace the information as appropriate.
+# 4. Set your git config to use the env var to authenticate https pushes.
+#    Make sure to include your username in this command as appropriate:
+#    git config --global credential.helper '!f() { echo username=yourghusername; echo "password=$GH_TOKEN"; };f'
+export GH_TOKEN="write-token-goes-here"

--- a/push2slac-epics-via-pat.sh
+++ b/push2slac-epics-via-pat.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Usage: ./push2slac-epics-via-pat.sh
+#  Updates all GitHub-mirrored EPICS module packages with a remote
+#  named "github-slac".
+#
+#  Based on the previous push2slac-epics-via-ssh.sh script
+#
+#  Requires a fine-grained PAT with the following permissions:
+#    1. Metadata (read)
+#    2. Content (write)
+
+SLEEP_PERIOD=2
+
+if [ -z "$GIT_TOP" ]; then
+  echo "GIT_TOP unset." 1>&2
+  exit 1
+fi
+
+get_bad_commits() {
+  # List all bad commits in the repository: that is, those without author names and e-mails
+  git log --all --oneline --pretty=tformat:"%H %an:%aE" | \
+    sed -E -e '/\S* \S+:\S+/d' -e 's/(\S+) .*$/--no-contains \1/'
+}
+
+get_things_to_push() {
+  bad_commits=$(get_bad_commits | tr '\n' ' ')
+  [ -n "${bad_commits}" ] && echo "Skipping bad commits: ${bad_commits}" 1>&2
+  # Branches without bad commits:
+  git for-each-ref --format='%(refname:short)' refs/heads/ ${bad_commits}
+  # Tags without bad commits:
+  git tag ${bad_commits}
+}
+
+for gitdir in ${GIT_TOP}/package/epics/modules/*.git ${GIT_TOP}/package/epics/base/base.git
+do
+    pushd "$gitdir" &> /dev/null || continue
+    git config --global --add safe.directory $(pwd -P) &> /dev/null
+    (git remote get-url --push github-slac-https &> /dev/null) && (
+        echo "* Updating $gitdir ..."
+        # git push --dry-run --mirror github-slac-https
+        to_push=$(get_things_to_push)
+        if [ -z "$to_push" ]; then
+          echo "Nothing to push. All refs have invalid commits?"
+          continue
+        fi
+        git push github-slac-https ${to_push} || sleep 5
+        # This may take a while, but we often get rate-limited as we hit GitHub
+        # quite a bit here:
+        sleep "${SLEEP_PERIOD}"
+    ) || (
+        echo "* $(basename $gitdir) is not on slac-epics"
+    )
+    popd &> /dev/null || exit 1
+done

--- a/slac-epics_template.sh
+++ b/slac-epics_template.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Use this file to authenticate slac-epics-pushing cron jobs.
+# You can get a github fine-grained PAT in the github settings.
+#
+# You need the following "repository permissions" for "all repositories"
+# in the slac-epics org. NOTE: not "organization permissions"!
+# 1. Read access to metadata
+# 2. Write access to contents
+# 3. Write access to administration
+#
+# For the user who is to run the cron jobs:
+# 1. Copy this to your home area as ~/.slac-epics.sh
+# 2. Change the write permissions so that nobody but you can rwx it:
+#    chmod 700 ~/.slac-epics.sh
+# 3. Replace the information as appropriate.
+# 4. Set your git config to use the env var to authenticate https pushes.
+#    Make sure to include your username in this command as appropriate:
+#    git config --global credential.helper '!f() { echo username=yourghusername; echo "password=$GH_TOKEN"; };f'
+export GH_TOKEN="write-token-goes-here"

--- a/sync_device_config.sh
+++ b/sync_device_config.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /cds/group/pcds/engineering_tools/latest-released/scripts/pcds_conda
+source "${HOME}/.pcdshub.sh"
 
 device_config_directories=(
   /cds/group/pcds/pyps/apps/hutch-python/device_config
@@ -15,7 +16,7 @@ for path in ${device_config_directories[@]}; do
   pwd
   set -x
   git commit -am "Automatic backup @ $(date)"
-  git push origin-ssh deploy || echo "Failed: git push failure '$path'"
+  git push origin-https deploy || echo "Failed: git push failure '$path'"
   gh pr create -B master -H deploy -b "$pr_body" -t "$pr_title" || echo "PR creation failed; may already exist"
   set +x
 done

--- a/sync_epics_modules.sh
+++ b/sync_epics_modules.sh
@@ -14,9 +14,10 @@ echo "** Working directory:"
 pwd
 
 echo "** Creating new repositories, if necessary:"
+source "${HOME}/.slac-epics.sh"
 ./create-new-slac-epics-repos.sh
 
 echo "** Synchronizing existing repositories:"
-./push2slac-epics-via-ssh.sh
+./push2slac-epics-via-pat.sh
 
 echo "Done."

--- a/sync_pcdshub.sh
+++ b/sync_pcdshub.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+source "${HOME}/.pcdshub.sh"
 directories=(
   /cds/group/pcds/gateway
   /cds/group/pcds/setup
@@ -17,7 +18,7 @@ for path in ${directories[@]}; do
   cd $path || (echo "Failed: Invalid path? '$path'" && continue)
   pwd
   set -x
-  git push --all pcdshub || echo "Failed: git push failure '$path'"
+  git push --all pcdshub-https || echo "Failed: git push failure '$path'"
   set +x
 done
 
@@ -33,6 +34,6 @@ for path in ${directories[@]}; do
   set -x
   git fetch --tags origin || echo "Failed: git fetch failure '$path'"
   git pull origin trunk:master trunk:trunk || echo "Failed: git pull failure '$path'"
-  git push --all pcdshub || echo "Failed: git push failure '$path'"
+  git push --all pcdshub-https || echo "Failed: git push failure '$path'"
   set +x
 done

--- a/update_hutch_python_backup.sh
+++ b/update_hutch_python_backup.sh
@@ -3,4 +3,5 @@
 cd /cds/group/pcds/shared_cron/current-hutch-python-backup || exit 1
 
 bash update.sh
-git push origin master
+source "${HOME}/.pcdshub.sh"
+git push origin-ssh master

--- a/update_plc_summary.sh
+++ b/update_plc_summary.sh
@@ -15,5 +15,6 @@ cd ../
 make gh-pages
 
 set +xe
-git push origin master gh-pages
+source "${HOME}/.pcdshub.sh"
+git push origin-https master gh-pages
 git checkout master


### PR DESCRIPTION
Previously: these scripts were using ssh remotes, which requires you to have an unsecured ssh key with either full account access or full single repo access to run them during cron jobs.

Now: these scripts assume you have a fine-grained PAT set up for running the cron jobs and the repo includes instructions on how to set this up.