### PR TITLE
MNT: re-enable pswww dashboard cron

### DIFF
--- a/crontab
+++ b/crontab
@@ -7,3 +7,4 @@
 0 2 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_pcdshub.sh
 0 3 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_module_usage.sh
 0 4 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_plc_summary.sh
+*/15 * * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_pswww_dashboards.sh


### PR DESCRIPTION
How do we want to manage additions to the shared cron list?  This got left out when Ken left I think.  

I could register the cron myself, but that might lead confusion as to who registered which cron.  @ZLLentz do you just load this crontab on your account?  Or do you have others in addition?