### PR TITLE
ENH: expand device config backup to include plc ansible configs

### DIFF
--- a/crontab
+++ b/crontab
@@ -4,6 +4,7 @@
 0 1 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_hutch_python_backup.sh
 0 1 * * * /cds/group/pcds/shared_cron/happi-to-confluence/cron_update.sh
 0 17 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_device_config.sh
+0 17 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_tcbsd_config.sh
 0 2 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_pcdshub.sh
 0 3 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_module_usage.sh
 0 4 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_plc_summary.sh

--- a/sync_device_config.sh
+++ b/sync_device_config.sh
@@ -5,6 +5,7 @@ source "${HOME}/.pcdshub.sh"
 
 device_config_directories=(
   /cds/group/pcds/pyps/apps/hutch-python/device_config
+  /cds/group/pcds/tcbsd/twincat-bsd-ansible
 )
 
 pr_title="Deploy branch status - $(date +"%B %Y")"

--- a/sync_tcbsd_config.sh
+++ b/sync_tcbsd_config.sh
@@ -3,20 +3,26 @@
 source /cds/group/pcds/engineering_tools/latest-released/scripts/pcds_conda
 source "${HOME}/.pcdshub.sh"
 
-device_config_directories=(
-  /cds/group/pcds/pyps/apps/hutch-python/device_config
+bsd_config_directories=(
+  /cds/group/pcds/tcbsd/twincat-bsd-ansible
+)
+add_directories=(
+  host_vars
 )
 
 pr_title="Deploy branch status - $(date +"%B %Y")"
 pr_body="** This PR was created automatically ** This PR can be used to easily see when cron-based pushes to GitHub happen, and allow us an opportunity to review changes prior to merging into master."
 
-for path in ${device_config_directories[@]}; do
+for path in "${bsd_config_directories[@]}"; do
   echo -e "\nSynchronizing: $path"
-  cd $path || (echo "Failed: Invalid path? '$path'" && continue)
+  cd "${path}" || (echo "Failed: Invalid path? '$path'" && continue)
   pwd
   set -x
+  for dir in "${add_directories[@]}"; do
+    git add "${dir}"/*
+  done
   git commit -am "Automatic backup @ $(date)"
-  git push origin-https deploy || echo "Failed: git push failure '$path'"
-  gh pr create -B master -H deploy -b "$pr_body" -t "$pr_title" || echo "PR creation failed; may already exist"
+  git push origin-https deploy || echo "Failed: git push failure '${path}'"
+  gh pr create -B master -H deploy -b "${pr_body}" -t "${pr_title}" || echo "PR creation failed; may already exist"
   set +x
 done


### PR DESCRIPTION
Add github daily pushes and monthly PRs for twincat-bsd-ansible's deploy branch

This is already live in the shared cron folder for testing

This script seems like a natural place to add other configs that need a deploy branch pushed.
See https://confluence.slac.stanford.edu/display/PCDS/TcBSD+Ansible+Workflows