### PR TITLE
ENH: Skip git repositories with a 'disable_mirror' file in them

### DIFF
--- a/push2slac-epics-via-pat.sh
+++ b/push2slac-epics-via-pat.sh
@@ -35,6 +35,7 @@ get_things_to_push() {
 for gitdir in ${GIT_TOP}/package/epics/modules/*.git ${GIT_TOP}/package/epics/base/base.git
 do
     pushd "$gitdir" &> /dev/null || continue
+	[ -f "disable_mirror" ] && continue
     git config --global --add safe.directory $(pwd -P) &> /dev/null
     (git remote get-url --push github-slac-https &> /dev/null) && (
         echo "* Updating $gitdir ..."


### PR DESCRIPTION
We may want to keep the AFS git repositories around for a while, even after they've been migrated. In that case, we also don't want to mirror them!