### PR TITLE
FIX: remove defunct afs pushes

### DIFF
--- a/sync_pcdshub.sh
+++ b/sync_pcdshub.sh
@@ -9,8 +9,6 @@ directories=(
   /cds/data/iocCommon/rhel7-x86_64
   /cds/data/iocCommon/All
   /cds/data/iocCommon/hosts
-  /afs/slac.stanford.edu/g/cd/swe/git/repos/slac/iocmgmt/IocManager.git
-  /afs/slac.stanford.edu/g/cd/swe/git/repos/package/epics/ioc/common/pvNotepad.git
 )
 
 for path in ${directories[@]}; do


### PR DESCRIPTION
- AFS will be going away
- The iocmanager is now managed primarily from github
- the pv notepad sync was pointing to an out of date repo, the new parent is on github and is ioc-common-pvNotepad