### PR TITLE
ENH: add cron job to pull from acr pydm screens

### DIFF
--- a/crontab
+++ b/crontab
@@ -10,3 +10,4 @@
 0 4 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_plc_summary.sh
 */15 * * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_pswww_dashboards.sh
 0 0 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_atef_config.sh
+0 17 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/pull_acr_pydm.sh

--- a/pull_acr_pydm.sh
+++ b/pull_acr_pydm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+#
+# Pulls recent changes to ACR's PyDM screens into the ECS deploy folder
+# See /cds/group/pcds/package/epics/lcls/tools/pydm/display
+# These git repos are on AFS at time of writing.
+# If they move, please update their "origin" remote to the new location.
+#
+
+set -e
+cd /cds/group/pcds/package/epics/lcls/tools/pydm/display
+for dname in *
+do
+    if [ -d "$dname" ]
+    then
+        echo "Updating ${dname}"
+        pushd "$dname"
+        git pull origin master
+        popd
+    fi
+done


### PR DESCRIPTION
Simple script that just does a `git pull` for these pydm repos
See https://jira.slac.stanford.edu/browse/ECS-7395 for context

I tested the script manually and it seems to work (provided your host has access to afs...)