### PR TITLE
ENH: also commit pyps/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,25 @@ from deploy (prod) to master.
 
 ## ``sync_pcdshub.sh``
 
-This updates a variety of repositories on
+This pushes recent commits to a variety of repositories on
 [pcdshub](https://github.com/pcdshub/), including:
 
 * [gateway-setup](https://github.com/pcdshub/gateway-setup)
 * [epics-setup](https://github.com/pcdshub/epics-setup)
-* [epics-config](https://github.com/pcdshub/epics-config)
 * [all-deployed-iocs](https://github.com/pcdshub/all-deployed-iocs)
 * [iocCommon/rhel7-x86_64](https://github.com/pcdshub/iocCommon-rhel7/)
 * [iocCommon/All](https://github.com/pcdshub/iocCommon-All)
 * [iocCommon/hosts](https://github.com/pcdshub/iocCommon-hosts)
 * [IocManager](https://github.com/pcdshub/IocManager)
 * [pvNotePad](https://github.com/pcdshub/pvNotepad)
+
+## ``sync_pcdshub_auto_commit.sh``
+
+This is an extension of sync_pcdshub.sh that also creates new commits.
+It manages:
+
+* [epics-config](https://github.com/pcdshub/epics-config) (which is `/cds/group/pcds/pyps/config`)
+
 
 ## ``sync_ui_dev.sh``
 

--- a/crontab
+++ b/crontab
@@ -6,6 +6,7 @@
 0 17 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_ui_dev.sh
 0 17 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_tcbsd_config.sh
 0 2 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_pcdshub.sh
+0 2 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_pcdshub_auto_commit.sh
 0 3 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_module_usage.sh
 0 4 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_plc_summary.sh
 */15 * * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_pswww_dashboards.sh

--- a/sync_pcdshub_auto_commit.sh
+++ b/sync_pcdshub_auto_commit.sh
@@ -3,12 +3,7 @@
 # shellcheck disable=SC1091
 source "${HOME}/.pcdshub.sh"
 directories=(
-  /cds/group/pcds/gateway
-  /cds/group/pcds/setup
-  /cds/data/iocData/.all_iocs
-  /cds/data/iocCommon/rhel7-x86_64
-  /cds/data/iocCommon/All
-  /cds/data/iocCommon/hosts
+  /cds/group/pcds/pyps/config
 )
 
 for path in "${directories[@]}"; do
@@ -20,7 +15,9 @@ for path in "${directories[@]}"; do
   cd "${path}" || continue
   pwd
   set -x
-  git push --all pcdshub-https || echo "Failed: git push failure '$path'"
+  git add -- *
+  git commit -am "Automatic backup @ $(date)"
+  git push origin-https master || echo "Failed: git push failure '$path'"
   set +x
 done
 

--- a/sync_pcdshub_auto_commit.sh
+++ b/sync_pcdshub_auto_commit.sh
@@ -17,7 +17,7 @@ for path in "${directories[@]}"; do
   set -x
   git add -- *
   git commit -am "Automatic backup @ $(date)"
-  git push origin-https master || echo "Failed: git push failure '$path'"
+  git push pcdshub-https master || echo "Failed: git push failure '$path'"
   set +x
 done
 


### PR DESCRIPTION
The previous cron job automatically pushed from `/cds/group/pcds/epics/config` (which is a symbolic link to `/cds/group/pyps/config`), but now we'd like to automatically commit too so we can keep a somewhat accurate track of IOCs over time when people opt not to manually commit configuration changes to iocmanager.

See https://jira.slac.stanford.edu/browse/ECS-7690

The script was based on the ui backup script and also fixes some shellcheck warnings.

It creates commits like https://github.com/pcdshub/epics-config/commit/c7a4fa79126a15d5fbe5f979fd9bdb015af8fc47