### PR TITLE
ENH: add cron for updating the rocky9 live status page daily at 5am

### DIFF
--- a/crontab
+++ b/crontab
@@ -12,3 +12,4 @@
 */15 * * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_pswww_dashboards.sh
 0 0 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/sync_atef_config.sh
 0 17 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/pull_acr_pydm.sh
+0 5 * * * /cds/group/pcds/shared_cron/shared-cron-jobs/update_rocky9_status.sh

--- a/update_rocky9_status.sh
+++ b/update_rocky9_status.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+# Location to store confluence state as we can no longer embed it directly
+# into the pages:
+export CONFLUENCE_STATE_PATH=/cds/group/pcds/shared_cron/shared-cron-jobs/state
+
+cd /cds/group/pcds/shared_cron/iocmanager
+# shellcheck disable=SC1091
+source ./scripts/default_env
+echo "generating table..."
+"${IOCMAN_PY_BIN}"/python -m iocmanager.scripts.survey_os --confluence-table > rocky9.html
+
+cd /cds/group/pcds/shared_cron/shared-cron-jobs
+
+# Whoever runs this needs their own PATs with write permissions
+# See confluence_template.sh in this repo
+# Copy to your home area with restricted read permissions and fill in username/token
+# -rwx------ 1 zlentz ps-pcds 105 Nov 17 16:05 /cds/home/z/zlentz/.confluence.sh
+# shellcheck disable=SC1090
+source ~/.confluence.sh
+echo "uploading table if new..."
+"${IOCMAN_PY_BIN}"/python confluence_page_from_html.py "/cds/group/pcds/shared_cron/iocmanager/rocky9.html" "PCDS/Rocky9 EPICS IOC Migration Live Info"
+echo "done"


### PR DESCRIPTION
I used the other confluence scripts as a starting point and substituted my html from iocmanager.
I've deployed iocmanager in the filetree at this location to control the versioning closely.

I picked 5am to make the upload at a different time when compared to the other confluence uploads in case there are any rate/volume limiters.

When run manually, this uploaded an update to https://confluence.slac.stanford.edu/spaces/PCDS/pages/623424952/Rocky9+EPICS+IOC+Migration+Live+Info